### PR TITLE
Fixes Issue#27, Key "enter_vehicle_distance" not found

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name":"TheFatController",
-	"version":"3.0.1",
+	"version":"3.0.2",
 	"author":"Choumiko, JamesOFarrell",
 	"factorio_version": "0.16",
 	"title":"The Fat Controller",

--- a/prototypes/fatcontroller.lua
+++ b/prototypes/fatcontroller.lua
@@ -46,6 +46,7 @@ data:extend({
       item_pickup_distance = 0,
       loot_pickup_distance = 0,
       ticks_to_stay_in_combat = 0,
+      enter_vehicle_distance = 0,
 
       subgroup = "creatures",
       order="z",


### PR DESCRIPTION
Teensy update that adds a property required by 0.16.22 to the entity object that replaces the player when they're using the FAT controller.
Fixes [#27](https://github.com/Choumiko/TheFatController/issues/27)