### PR TITLE
Update Alerts.lua

### DIFF
--- a/Alerts.lua
+++ b/Alerts.lua
@@ -5,7 +5,7 @@
 -- @type Alerts
 Alerts = {}
 Alerts.electric_locomotives = {
-    ['electric-locomotive'] = true,
+    ['electric-locomotive-mk1'] = true,
     ['electric-locomotive-mk2'] = true,
     ['electric-locomotive-mk3'] = true,
     ['hybrid-train'] = true


### PR DESCRIPTION
Fixed support for Electric Trains:

 `'electric-locomotive'` was renamed to `'electric-locomotive-mk1'` in the latest update for Electric Trains.
Changed Alerts.lua to fix "low fuel" alert for MK1 Electric Trains